### PR TITLE
Fixes heap issues with large imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 logs
 .vscode
 .idea
+tmp

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ indicate where the JSON log file was written to.
 
 **--maxFiles (-f)** Max number of files to parse per directory. Use to preview the entire import.
 
+**--fileOpenLimit** Max number of files to read at any given time. Override if seeing an EMFILE error.
+
+**--checkpointLimit** Number of accounts to process before saving a checkpoint
+
+**--checkpointDir** Directory to save checkpoint files to
+
 **--logLevel (-l)** Logging level. Defaults to `info`.
 
 - Options: `error`, `warn`, `info`, `verbose`, `debug`, `silly`

--- a/README.md
+++ b/README.md
@@ -122,21 +122,35 @@ Max number of concurrent transactions. Defaults to `30`.
 
 #### `--maxFiles (-f)`
 
-Max number of files to parse per directory. Use to preview the entire import.
+Max number of files to parse per directory. You can use this to preview a large import. For example, if you set the argument `--maxFiles 50`, the import tool will only run for the first 50 accounts, groups, directories, and other stormpath objects that are imported.
+
+- Example: `--maxFiles 50`
 
 #### `--checkpointDir`
 
-When the import script starts, it tries to map the Stormpath data model to the Okta model - for example, finding all unique custom schema attributes in the Account objects, or mapping linked Accounts to the same Okta user. For large exports, this can take a long time and sometimes cause memory issues.
+When the import script starts, it tries to map the Stormpath data model to the Okta model - for example, finding all unique custom schema attributes in the Account objects, or mapping linked Accounts to the same Okta user. For large exports, this can take a long time and sometime cause CPU or memory issues.
 
-This state is saved incrementally to the `--checkpointDir`, which defaults to `{stormpath-migration}/tmp`. If there are errors that cause the import script to fail, you can just re-run the script. It will load this incremental state from the checkpoint directory, and skip the introspection work that completed on the previous run.
+Incremental import state is saved to the `--checkpointDir`, which defaults to `{cwd}/tmp`. If the import script is stopped, it will load this incremental state on the next run.
 
-#### `--checkpointLimit`
+**Note**, when running from a saved state, warnings and messages from previous runs will not be written to the console. Output from previous runs is stored in the `logs` directory.
 
-The number of accounts to process before saving the current state to the `--checkpointDir`. This defaults to `10000`, which means that for every 10,000 accounts that are processed, a checkpoint is saved to the checkpoint directory.
+- Example: `--checkpointDir /Users/me/tmp`
+
+#### `--checkpointProgressLimit`
+
+The number of accounts to process before logging a progress message to the console. This value is only used during the initial phase of the import, when the import tool introspects the Stormpath export data.
+
+If you are working with a large export, you may want to increase this limit to reduce the number of messages that are logged to the console. The default value is `10000`.
+
+- Example: `--checkpointProgressLimit 50000`
 
 #### `--fileOpenLimit`
 
-Max number of files to read in parallel. We use this to limit how many files we open at a given time from the export directory. You should normally not need to override this option unless you see an [EMFILE](https://nodejs.org/api/errors.html#errors_common_system_errors) error in the error logs. Defaults to `1000`.
+Max number of files to read concurrently from the Stormpath export directory. For large exports, you may want to raise this limit to increase thoroughput in processing the Stormpath export files.
+
+**Note**, raising this limit will increase the CPU and memory usage of the import tool. Defaults to `100`.
+
+- Example: `--fileOpenLimit 1000`
 
 #### `--logLevel (-l)`
 

--- a/README.md
+++ b/README.md
@@ -82,23 +82,31 @@ indicate where the JSON log file was written to.
 
 ### Required Args
 
-**--stormPathBaseDir (-b)** Root directory where your Stormpath tenant export data lives
+#### `--stormPathBaseDir (-b)`
+
+Root directory where your Stormpath tenant export data lives
 
 - Example: `--stormPathBaseDir ~/Desktop/stormpath-exports/683IDSZVtUQewtFoqVrIEe`
 
-**--oktaBaseUrl (-u)** Base URL of your Okta tenant
+#### `--oktaBaseUrl (-u)`
+
+Base URL of your Okta tenant
 
 - Example: `--oktaBaseUrl https://your-org.okta.com`
 
-**--oktaApiToken (-t)** API token for your Okta tenant (SSWS token)
+#### `--oktaApiToken (-t)`
+
+API token for your Okta tenant (SSWS token)
 
 - Example: `--oktaApiToken 00gdoRRz2HUBdy06kTDwTOiPeVInGKpKfG-H4P_Lij`
 
 ### Optional Args
 
-**--customData (-d)** Strategy for importing Stormpath Account custom data. Defaults to `flatten`.
+#### `--customData (-d)`
 
-- Options
+Strategy for importing Stormpath Account custom data. Defaults to `flatten`.
+
+- Options:
 
   - `flatten` - Add [custom user profile schema properties](http://developer.okta.com/docs/api/resources/schemas.html#user-profile-schema-property-object) for each custom data property. Use this for simple custom data objects.
   - `stringify` - Stringify the Account custom data object into one `customData` [custom user profile schema property](http://developer.okta.com/docs/api/resources/schemas.html#user-profile-schema-property-object). Use this for more complex custom data objects.
@@ -106,19 +114,33 @@ indicate where the JSON log file was written to.
 
 - Example: `--customData stringify`
 
-**--concurrencyLimit (-c)** Max number of concurrent transactions. Defaults to `30`.
+#### `--concurrencyLimit (-c)`
+
+Max number of concurrent transactions. Defaults to `30`.
 
 - Example: `--concurrencyLimit 200`
 
-**--maxFiles (-f)** Max number of files to parse per directory. Use to preview the entire import.
+#### `--maxFiles (-f)`
 
-**--fileOpenLimit** Max number of files to read at any given time. Override if seeing an EMFILE error.
+Max number of files to parse per directory. Use to preview the entire import.
 
-**--checkpointLimit** Number of accounts to process before saving a checkpoint
+#### `--checkpointDir`
 
-**--checkpointDir** Directory to save checkpoint files to
+When the import script starts, it tries to map the Stormpath data model to the Okta model - for example, finding all unique custom schema attributes in the Account objects, or mapping linked Accounts to the same Okta user. For large exports, this can take a long time and sometimes cause memory issues.
 
-**--logLevel (-l)** Logging level. Defaults to `info`.
+This state is saved incrementally to the `--checkpointDir`, which defaults to `{stormpath-migration}/tmp`. If there are errors that cause the import script to fail, you can just re-run the script. It will load this incremental state from the checkpoint directory, and skip the introspection work that completed on the previous run.
+
+#### `--checkpointLimit`
+
+The number of accounts to process before saving the current state to the `--checkpointDir`. This defaults to `10000`, which means that for every 10,000 accounts that are processed, a checkpoint is saved to the checkpoint directory.
+
+#### `--fileOpenLimit`
+
+Max number of files to read in parallel. We use this to limit how many files we open at a given time from the export directory. You should normally not need to override this option unless you see an [EMFILE](https://nodejs.org/api/errors.html#errors_common_system_errors) error in the error logs. Defaults to `1000`.
+
+#### `--logLevel (-l)`
+
+Logging level. Defaults to `info`.
 
 - Options: `error`, `warn`, `info`, `verbose`, `debug`, `silly`
 - Example: `--logLevel verbose`

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Max number of concurrent transactions. Defaults to `30`.
 
 #### `--maxFiles (-f)`
 
-Max number of files to parse per directory. You can use this to preview a large import. For example, if you set the argument `--maxFiles 50`, the import tool will only run for the first 50 accounts, groups, directories, and other stormpath objects that are imported.
+Max number of files to parse per directory. You can use this to preview a large import. For example, if you set the argument `--maxFiles 50`, the import tool will only run for the first 50 accounts, groups, directories, and other Stormpath objects that are imported.
 
 - Example: `--maxFiles 50`
 

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -29,7 +29,7 @@ logger.info(`Writing log output to ${logger.logFile}`);
 
 async function migrate() {
   try {
-    console.time('migrate');
+    const timer = logger.startTimer();
 
     await introspect();
     await migrateCustomSchema();
@@ -40,8 +40,7 @@ async function migrate() {
     await migrateApplications();
 
     logger.header('Done');
-    logger.info(`Wrote log output to ${logger.logFile}`);
-    console.timeEnd('migrate');
+    timer.done(`Wrote log output to ${logger.logFile}`);
   } catch (err) {
     logger.error(err);
   }

--- a/functions/add-groups-to-app.js
+++ b/functions/add-groups-to-app.js
@@ -9,7 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-const ConcurrencyPool = require('../util/concurrency-pool');
+const { each } = require('../util/concurrency');
 const ApiError = require('../util/api-error');
 const config = require('../util/config');
 const rs = require('../util/request-scheduler');
@@ -17,8 +17,7 @@ const logger = require('../util/logger');
 
 async function addGroupsToApp(appInstanceId, groupIds) {
   logger.verbose(`Adding groupIds=${groupIds} to appInstanceId=${appInstanceId}`);
-  const pool = new ConcurrencyPool(config.concurrencyLimit);
-  return pool.each(groupIds, async (groupId) => {
+  return each(groupIds, async (groupId) => {
     logger.verbose(`Adding groupId=${groupId} to appInstanceId=${appInstanceId}`);
     try {
       await rs.put({ url: `/api/v1/apps/${appInstanceId}/groups/${groupId}` });
@@ -26,7 +25,7 @@ async function addGroupsToApp(appInstanceId, groupIds) {
     } catch (err) {
       logger.error(new ApiError(`Failed to assign groupId=${groupId} to appInstanceId=${appInstanceId}`, err));
     }
-  });
+  }, config.concurrencyLimit);
 }
 
 module.exports = addGroupsToApp;

--- a/functions/add-users-to-group.js
+++ b/functions/add-users-to-group.js
@@ -9,22 +9,21 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-const ConcurrencyPool = require('../util/concurrency-pool');
+const { each } = require('../util/concurrency');
 const ApiError = require('../util/api-error');
 const logger = require('../util/logger');
 const rs = require('../util/request-scheduler');
 const config = require('../util/config');
 
 async function addUsersToGroup(groupId, userIds) {
-  const pool = new ConcurrencyPool(config.concurrencyLimit);
-  return pool.each(userIds, async (userId) => {
+  return each(userIds, async (userId) => {
     try {
       await rs.put({ url: `/api/v1/groups/${groupId}/users/${userId}` });
       logger.created(`Group Membership uid=${userId} gid=${groupId}`);
     } catch (err) {
       logger.error(new ApiError(`Failed to add uid=${userId} to gid=${groupId}`, err));
     }
-  });
+  }, config.concurrencyLimit);
 }
 
 module.exports = addUsersToGroup;

--- a/migrators/migrate-applications.js
+++ b/migrators/migrate-applications.js
@@ -98,7 +98,7 @@ async function migrateApplications() {
   logger.header('Starting applications import');
   cache.accountStoreMap = await getAccountStoreMap();
 
-  const applications = stormpathExport.getApplications();
+  const applications = await stormpathExport.getApplications();
 
   logger.info(`Importing ${applications.length} applications`);
 

--- a/migrators/migrate-directories.js
+++ b/migrators/migrate-directories.js
@@ -126,7 +126,7 @@ async function migrateDirectory(directory) {
 async function migrateDirectories() {
   logger.header('Starting directories import');
   try {
-    const directories = stormpathExport.getDirectories();
+    const directories = await stormpathExport.getDirectories();
     logger.info(`Importing ${directories.length} directories`);
     await directories.each(migrateDirectory, { limit: 1 });
   } catch (err) {

--- a/migrators/migrate-directories.js
+++ b/migrators/migrate-directories.js
@@ -62,6 +62,7 @@ async function migrateSocial(type, directory) {
   cache.directoryIdpMap[directory.id] = idp.id;
   await addUsersFromDirectory(directory.id);
   return linkUsersFromSocialDirectory(directory.id);
+
 }
 
 async function migrateSaml(directory) {

--- a/migrators/migrate-directories.js
+++ b/migrators/migrate-directories.js
@@ -62,7 +62,6 @@ async function migrateSocial(type, directory) {
   cache.directoryIdpMap[directory.id] = idp.id;
   await addUsersFromDirectory(directory.id);
   return linkUsersFromSocialDirectory(directory.id);
-
 }
 
 async function migrateSaml(directory) {

--- a/migrators/migrate-groups.js
+++ b/migrators/migrate-groups.js
@@ -38,7 +38,7 @@ async function migrateGroup(membershipMap, stormpathGroup) {
 async function migrateGroups() {
   logger.header('Starting groups import');
 
-  const stormpathGroups = stormpathExport.getGroups();
+  const stormpathGroups = await stormpathExport.getGroups();
   logger.info(`Importing ${stormpathGroups.length} groups`);
 
   const membershipMap = await stormpathExport.getGroupMembershipMap();

--- a/migrators/migrate-organizations.js
+++ b/migrators/migrate-organizations.js
@@ -32,9 +32,9 @@ async function migrateOrg(org) {
   }
 }
 
-function migrateOrganizations() {
+async function migrateOrganizations() {
   logger.header('Starting organizations import');
-  const organizations = stormpathExport.getOrganizations();
+  const organizations = await stormpathExport.getOrganizations();
   logger.info(`Importing ${organizations.length} organizations`);
   return organizations.each(migrateOrg, { limit: 1 });
 }

--- a/migrators/util/add-users-from-organization.js
+++ b/migrators/util/add-users-from-organization.js
@@ -16,7 +16,7 @@ const config = require('../../util/config');
 const cache = require('./cache');
 
 async function getOrganizationAccountStoreMap() {
-  const mappings = stormpathExport.getOrganizationAccountStoreMappings();
+  const mappings = await stormpathExport.getOrganizationAccountStoreMappings();
   return mappings.mapToObject((mapping, map) => {
     const type = mapping.accountStoreType;
     const id = mapping.accountStoreId;

--- a/migrators/util/link-users-from-social-directory.js
+++ b/migrators/util/link-users-from-social-directory.js
@@ -31,11 +31,12 @@ function linkUsersFromSocialDirectory(directoryId) {
   const pool = new ConcurrencyPool(config.concurrencyLimit);
   return pool.each(userIds, async (userId) => {
     try {
-      const account = cache.userIdAccountMap[userId]
-      if (!account) {
+      const accountRef = cache.userIdAccountMap[userId];
+      if (!accountRef) {
         return error(userId, idpId, 'No unified account for user');
       }
 
+      const account = accountRef.getAccount();
       const externalId = account.getExternalIdForDirectory(directoryId);
       if (!externalId) {
         return error(userId, idpId, `No externalId found`);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
     "columnify": "^1.5.4",
+    "fs-extra": "^3.0.1",
     "generate-password": "^1.3.0",
     "parse-iso-duration": "^1.0.0",
     "prettyjson": "^1.2.1",

--- a/stormpath/account-ref.js
+++ b/stormpath/account-ref.js
@@ -10,30 +10,35 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
+const Account = require('./account');
 const JsonCheckpoint = require('../util/checkpoint').JsonCheckpoint;
-const config = require('../util/config');
 
-class Base extends JsonCheckpoint {
+class AccountRef extends JsonCheckpoint {
 
-  constructor(filePath) {
+  constructor(id) {
     super();
-    this.filePath = filePath;
+    this.id = id;
   }
 
   checkpointConfig() {
     return {
-      path: this.filePath.replace(`${config.stormPathBaseDir}/`, '').replace('.json', ''),
-      props: Object.keys(this)
+      path: `account-refs/${this.id}`,
+      props: ['id', 'oktaUserId', 'username', 'email', 'accountFilePath']
     };
   }
 
-  /**
-   * Override this to perform initialization options that only happen when
-   * loading from the export. Any properties that are created will be saved
-   * to the checkpoint file.
-   */
-  initializeFromExport() {}
+  getAccount() {
+    const account = new Account(this.accountFilePath);
+    account.restore();
+    return account;
+  }
+
+  async getAccountAsync() {
+    const account = new Account(this.accountFilePath);
+    await account.restoreAsync();
+    return account;
+  }
 
 }
 
-module.exports = Base;
+module.exports = AccountRef;

--- a/stormpath/account-store-mapping.js
+++ b/stormpath/account-store-mapping.js
@@ -13,13 +13,10 @@ const Base = require('./base');
 
 class AccountStoreMapping extends Base {
 
-  get accountStoreType() {
+  initializeFromExport() {
     const parts = this.accountStore.href.split('/');
-    return parts[parts.length - 2];
-  }
-
-  get accountStoreId() {
-    return this.accountStore.id;
+    this.accountStoreType = parts[parts.length - 2];
+    this.accountStoreId = this.accountStore.id;
   }
 
 }

--- a/stormpath/account.js
+++ b/stormpath/account.js
@@ -226,6 +226,39 @@ class Account extends Base {
     });
   }
 
+  checkpointConfig() {
+    const config = super.checkpointConfig();
+    config.props = [
+      'id',
+
+      // Our props
+      'apiKeys',
+      'accountIds',
+      'directoryIds',
+      'externalIds',
+      'recoveryAnswer',
+
+      // Profile Attributes
+      'username',
+      'email',
+      'givenName',
+      'middleName',
+      'surname',
+      'fullName',
+      'emailVerificationStatus',
+      'href',
+      'customData',
+      'apiKeys',
+
+      // Credentials
+      'password',
+
+      // Status
+      'status'
+    ];
+    return config;
+  }
+
   /**
    * Merges properties from another account into this account.
    * @param {Account} account

--- a/stormpath/account.js
+++ b/stormpath/account.js
@@ -208,8 +208,7 @@ function transformMCFCreds(password, accountIds) {
 
 class Account extends Base {
 
-  constructor(filePath, json, options) {
-    super(filePath, json);
+  initializeFromExport(options) {
     this.apiKeys = options.accountApiKeys[this.id] || [];
     this.accountIds = [this.id];
     this.directoryIds = [this.directory.id];
@@ -359,14 +358,6 @@ class Account extends Base {
     customData['stormpathMigrationRecoveryAnswer'] = transform(this.recoveryAnswer);
 
     return customData;
-  }
-
-  setOktaUserId(oktaUserId) {
-    this.oktaUserId = oktaUserId;
-  }
-
-  getOktaUserId() {
-    return this.oktaUserId;
   }
 
   getExternalIdForDirectory(directoryId) {

--- a/stormpath/application.js
+++ b/stormpath/application.js
@@ -61,9 +61,8 @@ function loadOAuthPolicy(application) {
 
 class Application extends Base {
 
-  constructor(filePath, json) {
-    super(filePath, json);
-    this.tokenLimits = loadOAuthPolicy(json);
+  initializeFromExport() {
+    this.tokenLimits = loadOAuthPolicy(this);
   }
 
 }

--- a/stormpath/directory.js
+++ b/stormpath/directory.js
@@ -120,11 +120,10 @@ function loadUserInfoMappingRules(directory) {
 
 class Directory extends Base {
 
-  constructor(filePath, json) {
-    super(filePath, json);
-    this.passwordPolicy = loadPasswordPolicy(json);
-    this.attributeMappings = loadUserInfoMappingRules(json);
-    if (json.provider.providerId === 'saml') {
+  initializeFromExport() {
+    this.passwordPolicy = loadPasswordPolicy(this);
+    this.attributeMappings = loadUserInfoMappingRules(this);
+    if (this.provider.providerId === 'saml') {
       this.signingCert = this.provider.encodedX509SigningCert
         .replace('-----BEGIN CERTIFICATE-----\n', '')
         .replace('\n-----END CERTIFICATE-----', '');

--- a/stormpath/stormpath-export.js
+++ b/stormpath/stormpath-export.js
@@ -19,7 +19,6 @@ const Base = require('./base');
 const Directory = require('./directory');
 const logger = require('../util/logger');
 const config = require('../util/config');
-const ConcurrencyPool = require('../util/concurrency-pool');
 const FileIterator = require('./file-iterator');
 
 class StormpathExport {
@@ -31,12 +30,14 @@ class StormpathExport {
   async getAccountLinks() {
     const accountLinks = new AccountLinks();
     const linkFiles = new FileIterator(`${this.baseDir}/accountLinks`, Base);
+    await linkFiles.initialize();
     await linkFiles.each((file) => accountLinks.addLink(file));
     return accountLinks;
   }
 
   async getAccounts(skipAccounts) {
     const apiKeys = new FileIterator(`${this.baseDir}/apiKeys`, Base);
+    await apiKeys.initialize();
     logger.verbose(`Mapping ${apiKeys.length} apiKeys to accounts`);
     const accountApiKeys = await apiKeys.mapToObject((apiKey, map) => {
       if (apiKey.status !== 'ENABLED') {
@@ -48,27 +49,38 @@ class StormpathExport {
       }
       map[accountId].push({ id: apiKey.id, secret: apiKey.secret });
     });
-    return new FileIterator(`${this.baseDir}/accounts`, Account, { accountApiKeys }, skipAccounts);
+    const accounts = new FileIterator(`${this.baseDir}/accounts`, Account, { accountApiKeys }, skipAccounts);
+    await accounts.initialize();
+    return accounts;
   }
 
-  getDirectories() {
-    return new FileIterator(`${this.baseDir}/directories`, Directory);
+  async getDirectories() {
+    const directories = new FileIterator(`${this.baseDir}/directories`, Directory);
+    await directories.initialize();
+    return directories;
   }
 
-  getApplications() {
-    return new FileIterator(`${this.baseDir}/applications`, Application);
+  async getApplications() {
+    const applications = new FileIterator(`${this.baseDir}/applications`, Application);
+    await applications.initialize();
+    return applications;
   }
 
-  getAccountStoreMappings() {
-    return new FileIterator(`${this.baseDir}/accountStoreMappings`, AccountStoreMapping);
+  async getAccountStoreMappings() {
+    const accountStoreMappings = new FileIterator(`${this.baseDir}/accountStoreMappings`, AccountStoreMapping);
+    await accountStoreMappings.initialize();
+    return accountStoreMappings;
   }
 
-  getGroups() {
-    return new FileIterator(`${this.baseDir}/groups`, Base);
+  async getGroups() {
+    const groups = new FileIterator(`${this.baseDir}/groups`, Base);
+    await groups.initialize();
+    return groups;
   }
 
   async getGroupMembershipMap() {
     const memberships = new FileIterator(`${this.baseDir}/groupMemberships`, Base);
+    await memberships.initialize();
     logger.verbose(`Mapping ${memberships.length} group memberships`);
     return memberships.mapToObject((membership, map) => {
       const groupId = membership.group.id;
@@ -79,12 +91,16 @@ class StormpathExport {
     });
   }
 
-  getOrganizations() {
-    return new FileIterator(`${this.baseDir}/organizations`, Base);
+  async getOrganizations() {
+    const organizations = new FileIterator(`${this.baseDir}/organizations`, Base);
+    await organizations.initialize();
+    return organizations;
   }
 
-  getOrganizationAccountStoreMappings() {
-    return new FileIterator(`${this.baseDir}/organizationAccountStoreMappings`, AccountStoreMapping);
+  async getOrganizationAccountStoreMappings() {
+    const mappings = new FileIterator(`${this.baseDir}/organizationAccountStoreMappings`, AccountStoreMapping);
+    await mappings.initialize();
+    return mappings;
   }
 
 }

--- a/stormpath/stormpath-export.js
+++ b/stormpath/stormpath-export.js
@@ -35,7 +35,7 @@ class StormpathExport {
     return accountLinks;
   }
 
-  async getAccounts() {
+  async getAccounts(skipAccounts) {
     const apiKeys = new FileIterator(`${this.baseDir}/apiKeys`, Base);
     logger.verbose(`Mapping ${apiKeys.length} apiKeys to accounts`);
     const accountApiKeys = await apiKeys.mapToObject((apiKey, map) => {
@@ -48,7 +48,7 @@ class StormpathExport {
       }
       map[accountId].push({ id: apiKey.id, secret: apiKey.secret });
     });
-    return new FileIterator(`${this.baseDir}/accounts`, Account, { accountApiKeys });
+    return new FileIterator(`${this.baseDir}/accounts`, Account, { accountApiKeys }, skipAccounts);
   }
 
   getDirectories() {

--- a/util/checkpoint.js
+++ b/util/checkpoint.js
@@ -1,0 +1,189 @@
+/*!
+ * Copyright (c) 2017, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+const Promise = require('bluebird');
+const path = require('path');
+const fs = require('fs-extra');
+const config = require('./config');
+const readFile = Promise.promisify(fs.readFile);
+const writeFile = Promise.promisify(fs.writeFile);
+const ConcurrencyPool = require('./concurrency-pool');
+const { info } = require('./logger');
+
+class BaseCheckpoint {
+
+  /**
+   * @return {object} config - path, type, properties
+   */
+  checkpointConfig() {
+    throw new Error('checkpointConfig must be implemented');
+  }
+
+  getCheckpointPathFromType(type) {
+    return path.resolve(
+      config.checkpointDir,
+      `${this.checkpointConfig().path}.${type}`
+    );
+  }
+
+  readFile() {
+    const filePath = this.getCheckpointPath();
+    if (!fs.existsSync(filePath)) {
+      return this.parseFile(null);
+    }
+    return this.parseFile(fs.readFileSync(filePath, 'utf8'));
+  }
+
+  async readFileAsync() {
+    const filePath = this.getCheckpointPath();
+    try {
+      const content = await readFile(filePath, 'utf8');
+      return this.parseFile(content);
+    } catch (e) {
+      return this.parseFile(null);
+    }
+  }
+
+  writeFile(content) {
+    const filePath = this.getCheckpointPath();
+    fs.ensureDirSync(path.dirname(filePath));
+    fs.writeFileSync(filePath, content);
+  }
+
+  async writeFileAsync(content) {
+    const filePath = this.getCheckpointPath();
+    await fs.ensureDir(path.dirname(filePath));
+    await writeFile(filePath, content);
+  }
+
+  appendFile(content) {
+    const filePath = this.getCheckpointPath();
+    fs.ensureDirSync(path.dirname(filePath));
+
+    if (fs.existsSync(filePath)) {
+      fs.appendFileSync(filePath, '\n' + content);
+    }
+    else {
+      fs.writeFileSync(filePath, content);
+    }
+  }
+
+}
+
+class JsonCheckpoint extends BaseCheckpoint {
+
+  getCheckpointPath() {
+    return this.getCheckpointPathFromType('json');
+  }
+
+  parseFile(content) {
+    return content ? JSON.parse(content) : {};
+  }
+
+  setProperties(props) {
+    Object.keys(props).forEach((key) => {
+      this[key] = props[key];
+    });
+  }
+
+  getProperties() {
+    const props = {};
+    this.checkpointConfig().props.forEach(key => props[key] = this[key]);
+    return props;
+  }
+
+  save() {
+    const props = this.getProperties();
+    this.writeFile(JSON.stringify(props, null, 2));
+  }
+
+  async saveAsync() {
+    const props = this.getProperties();
+    await this.writeFileAsync(JSON.stringify(props, null, 2));
+  }
+
+  restore() {
+    this.setProperties(this.readFile());
+  }
+
+  async restoreAsync() {
+    const props = await this.readFileAsync();
+    this.setProperties(props);
+  }
+
+}
+
+class LogCheckpoint extends BaseCheckpoint {
+
+  constructor(path) {
+    super();
+    this.path = path;
+    this.pendingItems = [];
+  }
+
+  checkpointConfig() {
+    return { path: this.path };
+  }
+
+  add(item) {
+    this.pendingItems.push(item);
+  }
+
+  getCheckpointPath() {
+    return this.getCheckpointPathFromType('txt');
+  }
+
+  parseFile(content) {
+    return content ? content.split('\n') : [];
+  }
+
+  save() {
+    this.appendFile(this.pendingItems.join('\n'));
+    this.pendingItems = [];
+  }
+
+  async processAsync(processFn, limit) {
+    info(`Loading log checkpoint file ${this.path}`);
+    const items = await this.readFileAsync();
+    if (items.length === 0) {
+      return;
+    }
+
+    info(`Processing ${items.length} log items`);
+    const pool = new ConcurrencyPool(limit);
+    await pool.each(items, async (item) => {
+      if (!item) {
+        return;
+      }
+      await processFn(item);
+    });
+  }
+
+  process(processFn) {
+    info(`Loading log checkpoint file ${this.path}`);
+    const items = this.readFile();
+    if (items.length === 0) {
+      return;
+    }
+
+    info(`Processing ${items.length} log items`);
+    for (let item of items) {
+      if (!item) {
+        continue;
+      }
+      processFn(item);
+    }
+  }
+
+}
+
+module.exports = { JsonCheckpoint, LogCheckpoint }

--- a/util/concurrency-pool.js
+++ b/util/concurrency-pool.js
@@ -9,7 +9,6 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
-const allSettled = require('./all-settled');
 
 function releaseFrom(pool) {
   return function () {
@@ -47,28 +46,6 @@ class ConcurrencyPool {
       reject
     });
     return promise;
-  }
-
-  each(list, fn) {
-    return allSettled(list.map(async (item) => {
-      const resource = await this.acquire();
-      try {
-        const res = await fn(item);
-        resource.release();
-        return res;
-      } catch (e) {
-        this.pending.forEach(item => item.reject());
-        throw e;
-      }
-    }));
-  }
-
-  async mapToObject(list, fn) {
-    const map = {};
-    await this.each(list, (item) => {
-      return fn(item, map);
-    });
-    return map;
   }
 
 }

--- a/util/concurrency.js
+++ b/util/concurrency.js
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) 2017, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+const Promise = require('bluebird');
+
+async function processList(list, fn) {
+  while (list.length > 0) {
+    await fn(list.shift());
+  }
+}
+
+/**
+ * Concurrently evaluates each item in a list (up to the limit) with the
+ * provided function. This function can be async, but must return a Promise to
+ * signal when it is complete.
+ *
+ * @param {array} list
+ * @param {function} fn
+ * @param {number} limit
+ */
+async function each(list, fn, limit) {
+  const promises = [];
+  for (let i = 0; i < limit; i++) {
+    promises.push(processList(list, fn));
+  }
+  await Promise.all(promises);
+}
+
+/**
+ * Evaluates a list with the provided function in batches of the limit. When
+ * a batch is finished, the batchFn is called with the total number of
+ * processed items. The evalFn and batchFn can both by async.
+ *
+ * @param {array} list
+ * @param {function} evalFn
+ * @param {function} batchFn
+ * @param {number} limit
+ */
+async function batch(list, evalFn, batchFn, limit) {
+  let numProcessed = 0;
+  while (list.length > 0) {
+    const promises = [];
+    for (let i = 0; i < limit; i++) {
+      if (list.length === 0) {
+        break;
+      }
+      const item = list.shift();
+      promises.push(evalFn(item));
+      numProcessed++;
+    }
+    await Promise.all(promises);
+    await batchFn(numProcessed);
+  }
+}
+
+/**
+ * Concurrently evaluates each item in a list (up to the limit) with the
+ * provided mapping function, and returns the constructed map.
+ *
+ * @param {array} list
+ * @param {function} fn
+ * @param {number} limit
+ */
+async function mapToObject(list, fn, limit) {
+  const map = {};
+  await each(list, item => fn(item, map), limit);
+  return map;
+}
+
+module.exports = { each, batch, mapToObject };

--- a/util/config.js
+++ b/util/config.js
@@ -60,19 +60,19 @@ const config = yargs
       alias: 'f'
     },
     fileOpenLimit: {
-      description: 'Max number of files to read at any given time. Override if seeing an EMFILE error.',
+      description: 'Max number of files to read at any given time.',
       required: false,
-      default: 1000
-    },
-    checkpointLimit: {
-      description: 'Number of accounts to process before saving a checkpoint',
-      required: false,
-      default: 10000
+      default: 100
     },
     checkpointDir: {
       description: 'Directory to save checkpoint files to',
       required: false,
-      default: path.resolve(__dirname, '../tmp')
+      default: path.resolve(process.cwd(), 'tmp')
+    },
+    checkpointProgressLimit: {
+      description: 'Number of accounts to process before logging progress message',
+      required: false,
+      default: 10000
     },
     logLevel: {
       description: 'Logging level',
@@ -91,6 +91,10 @@ const config = yargs
   })
   .version()
   .argv;
+
+if (config.stormPathBaseDir.endsWith('/')) {
+  config.stormPathBaseDir = config.stormPathBaseDir.slice(0, -1);
+}
 
 config.isCustomDataFlatten = config.customData === 'flatten';
 config.isCustomDataStringify = config.customData === 'stringify';

--- a/util/config.js
+++ b/util/config.js
@@ -11,6 +11,7 @@
  */
 const yargs = require('yargs');
 const fs = require('fs');
+const path = require('path');
 
 const usage = `
 Migration tool to import Stormpath data into an Okta tenant
@@ -57,6 +58,21 @@ const config = yargs
       description: 'Max number of files to parse per directory. Use to preview the entire import.',
       required: false,
       alias: 'f'
+    },
+    fileOpenLimit: {
+      description: 'Max number of files to read at any given time. Override if seeing an EMFILE error.',
+      required: false,
+      default: 1000
+    },
+    checkpointLimit: {
+      description: 'Number of accounts to process before saving a checkpoint',
+      required: false,
+      default: 10000
+    },
+    checkpointDir: {
+      description: 'Directory to save checkpoint files to',
+      required: false,
+      default: path.resolve(__dirname, '../tmp')
     },
     logLevel: {
       description: 'Logging level',

--- a/util/request-scheduler.js
+++ b/util/request-scheduler.js
@@ -22,7 +22,9 @@ const packageJson = require('../package.json');
 // The max number of concurrent requests. Note, this is different from the
 // concurrencyLimit in the config, which defines the max number of concurrent
 // transactions (which can encompass more than one request).
-const REQUEST_CONCURRENCY_LIMIT = 100;
+// Note: Endpoints have different concurrency limits - for example,
+// api/v1/apps/{id}/user/types/default?expand=schema has a limit of 100
+const REQUEST_CONCURRENCY_LIMIT = 70;
 
 /**
  * Calculates the time to schedule the next request in milliseconds - returns 0

--- a/util/schema-properties.js
+++ b/util/schema-properties.js
@@ -9,6 +9,7 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+const JsonCheckpoint = require('./checkpoint').JsonCheckpoint;
 const logger = require('./logger');
 
 const HIDDEN_FIELDS = [
@@ -70,10 +71,18 @@ function compareKeys(key1, key2) {
   return Number(key1.replace(apiKey, '')) - Number(key2.replace(apiKey, ''));
 }
 
-class SchemaProperties {
+class SchemaProperties extends JsonCheckpoint {
 
   constructor() {
+    super();
     this.properties = {};
+  }
+
+  checkpointConfig() {
+    return {
+      path: 'account-meta/schema',
+      props: ['properties']
+    };
   }
 
   add(key, type) {


### PR DESCRIPTION
### Initial

- Uses account refs instead of full accounts, and loads accounts dynamically
- Stores incremental processing in new checkpoint directory, and loads this
  data on subsequent runs
- Fixes a couple issues where objects were not being cleaned up correctly

### Update

Reduces Mem and CPU usage
- No longer maps promises for each file being processed (reduced memory)
- All sync file i/o switched to async (reduced cpu/mem)
- Batch accounts in introspect for every --fileOpenLimit processed, and save
  checkpoint to the file system (reduced cpu/mem)
- Caches dir existence checks (reduced cpu)

Minor:
- Fixes file-iterator issue with reading more files after using skip
- Fixes issue with bad lookups when stormpathBaseDir includes trailing slash

RESOLVES OKTA-131500