### PR TITLE
Fixes heap overflow issue with linked accounts

### DIFF
--- a/stormpath/account-links.js
+++ b/stormpath/account-links.js
@@ -42,6 +42,11 @@ class AccountLinks {
       this.links[rightAccountId] = rightRef;
     }
 
+    // Both accounts are already linked
+    if (leftRef === rightRef) {
+      return;
+    }
+
     // And then merge all accountIds from the right to the left, updating
     // all references to point to the left.
     for (let accountId of rightRef) {


### PR DESCRIPTION
The base issue occurs when we have a link structure like this:

A <- B
A <- C
B <- C

The import tool tries to get to a state where all account links are tied together (anytime we see an accountId, we want them to map to all other linked accounts). The end state should look like this:

A = [A, B, C]
B = Pointer to A
C = Pointer to C

In this case, the tool didn't account for the pointers already existing - it was in a loop where it kept adding members to itself.

RESOLVES OKTA-132904