### PR TITLE
Fix "Cannot read property 'headers' of undefined"

### DIFF
--- a/util/request-scheduler.js
+++ b/util/request-scheduler.js
@@ -79,7 +79,7 @@ async function schedule(scheduler, msg, fn) {
     return res.body;
   } catch (err) {
     logger.silly(`Finished request id=${requestId} status=FAILURE`);
-    setTimeout(resource.release, timeToNextRequest(err));
+    setTimeout(resource.release, timeToNextRequest(res));
     throw err;
   }
 }


### PR DESCRIPTION
A colleague, @benracine, discovered a bug in the HTTP error handling that results in this error:

```
ADDING CUSTOM SCHEMA PROPERTIES:
ERROR
message: Failed to get current schema properties
stack:
"""
TypeError: Cannot read property 'headers' of undefined
at timeToNextRequest (.../util/request-scheduler.js:40:46)
at schedule (.../util/request-scheduler.js:82:34)
"""
name: Error
Failed to add custom schema properties, aborting script
```

This can be reproduced by using a bad domain, i.e. omitting the `.oktapreview.` from the URL.